### PR TITLE
Readme and example updated to reflect real parameter name for insiders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,26 @@ Plugin for [dotbot](https://github.com/anishathalye/dotbot). dotbot-vscode adds 
 This is an example file.
 ```yaml
 - vscode:
-    dbaeumer.vscode-eslint: 
+    dbaeumer.vscode-eslint:
         status: install
-        insider: true
-    eamodio.gitlens: 
+        insiders: true
+    eamodio.gitlens:
         status: uninstall
-        insider: true
+        insiders: true
     eg2.tslint:
         status: install
-        insider: false
+        insiders: false
 
-- vscodefile: 
+- vscodefile:
     file: Vscodefile
-    insider: true
+    insiders: true
 
-- vscodefile: 
+- vscodefile:
     file: Vscodefile
-    insider: false
+    insiders: false
 ```
 For `vscode` directive, you ought to specify the operation to install or uninstall, default is install.
 
 For `vscodefile` directive, you ought to generate a vscodefile using `code --list-extensions > $DIR/vscodefile` command.
 
 In other place, you run `./install -p dotbot-vscode/vscode.py -c vscode.packages.conf.yaml`, `dotbot-vscode` will uninstall the extensions which are installed but not in `vscodefile`, and install the extensions which are not installed but in `vscodefile`.
-

--- a/example/vscode.packages.conf.yaml
+++ b/example/vscode.packages.conf.yaml
@@ -1,18 +1,18 @@
 - vscode:
-    dbaeumer.vscode-eslint: 
+    dbaeumer.vscode-eslint:
         status: install
-        insider: true
-    eamodio.gitlens: 
+        insiders: true
+    eamodio.gitlens:
         status: uninstall
-        insider: true
+        insiders: true
     eg2.tslint:
         status: install
-        insider: false
+        insiders: false
 
-- vscodefile: 
+- vscodefile:
     file: Vscodefile
-    insider: true
+    insiders: true
 
-- vscodefile: 
+- vscodefile:
     file: Vscodefile
-    insider: false
+    insiders: false


### PR DESCRIPTION
Hi,

First - thank you for this plugin for dotbot!
Second - this PR updates readme and example, fixing the name of parameter for insiders version of VSCode.

If you try to use readme example as is, it will show an error during dotbot's install process because of this line

```python
elif len(data) == 2 and ("file" not in data or "insiders" not in data):
```