### PR TITLE
Python2 support for macOS (Whichcraft)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/whichcraft"]
+	path = lib/whichcraft
+	url = https://github.com/pydanny/whichcraft

--- a/vscode.py
+++ b/vscode.py
@@ -1,9 +1,16 @@
 # coding: utf-8
+import os
 import sys
-import shutil
 import dotbot
 
 from subprocess import check_output, call
+
+
+sys.path.append(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib", "whichcraft")
+)
+
+from whichcraft import which
 
 
 class VSCode(dotbot.Plugin):
@@ -38,7 +45,7 @@ class VSCode(dotbot.Plugin):
         vsfile = data["file"]
         return self._sync_vscodefile(vsfile, code)
 
-    def _handle_vscode(self, data: dict):
+    def _handle_vscode(self, data):
         if not isinstance(data, dict):
             self._log.error("Error format, please refer to documentation.")
             return False
@@ -117,10 +124,10 @@ class VSCodeInstance(object):
     def __init__(self, insiders=False):
         if not insiders:
             self._name = "Visual Studio Code"
-            self._binary = shutil.which("code")
+            self._binary = which("code")
         else:
             self._name = "Visual Studio Code Insiders"
-            self._binary = shutil.which("code-insiders")
+            self._binary = which("code-insiders")
 
     @property
     def installed(self):


### PR DESCRIPTION
Noticed this plugin wasn't running on macOS for me for a couple of reasons. There was a stray python3 type annotation in one of the function calls and `shutil.which` isn't available in 2.7.x.

I added `whichcraft` as a submodule and shim it in at the top of the vscode plugin script. `whichcraft` being a backport for python2.

Not sure if this is the prefered way of handling a depndancy to a plugin or not. I've tested it out on my dotfiles and it works. You do need to add an additional `git submodule update --init --recursive "dotbot-vscode"` line to the install script. Here's a link to [what that looks like](https://github.com/jamesstidard/dotfiles/blob/4243e72e60ed7c662e5b90a8ce0d48b4781140b9/install).